### PR TITLE
Update log2zram.logrotate

### DIFF
--- a/log2zram.logrotate
+++ b/log2zram.logrotate
@@ -1,13 +1,11 @@
-olddir /opt/zram/log.old
-createolddir 755 root root
-renamecopy
-
-/usr/local/share/log2zram/log/log2zram.log
-{
-	rotate 7
-	daily
-	missingok
-	notifempty
-	delaycompress
-	compress
+/usr/local/share/log2zram/log/log2zram.log {
+        olddir /opt/zram/log.old
+        createolddir 755 root root
+        renamecopy
+        rotate 7
+        daily
+        compress
+        delaycompress
+        missingok
+        notifempty
 }


### PR DESCRIPTION
Prior to commit, the provided logrotate configuration file results in the following errors:
Feb 06 12:48:15 XXX logrotate[3886]: error: 00_log2zram:4 lines must begin with a keyword or a filename (possibly in double quotes)
Feb 06 12:48:15 XXX logrotate[3886]: error: 00_log2zram:5 lines must begin with a keyword or a filename (possibly in double quotes)
Feb 06 12:48:15 XXX logrotate[3886]: error: 00_log2zram:15, unexpected text after }
I'm not entirely certain what OP was looking to accomplish; but at least this config file will process correctly.